### PR TITLE
Refactor function togglequickfix#IsOpened()

### DIFF
--- a/autoload/togglequickfix.vim
+++ b/autoload/togglequickfix.vim
@@ -18,13 +18,13 @@ endfunction "}}}
 
 fun! togglequickfix#IsOpened(typ) "{{{
     if a:typ == "qf"
-		let ids = getqflist({'winid' : 1})
+        let ids = getqflist({'winid' : 1})
     else
         " query location list window
-		let ids = getloclist(0, {'winid' : 1})
+        let ids = getloclist(0, {'winid' : 1})
     endif
 
-	return !empty(ids)
+    return !empty(ids)
 endfunction "}}}
 
 fun! togglequickfix#Has(typ) "{{{

--- a/autoload/togglequickfix.vim
+++ b/autoload/togglequickfix.vim
@@ -18,13 +18,13 @@ endfunction "}}}
 
 fun! togglequickfix#IsOpened(typ) "{{{
     if a:typ == "qf"
-        let id = getqflist({'winid' : 1}).winid
+		let ids = getqflist({'winid' : 1})
     else
         " query location list window
-        let id = getloclist(0, {'winid' : 1}).winid
+		let ids = getloclist(0, {'winid' : 1})
     endif
 
-    return id != 0
+	return !empty(ids)
 endfunction "}}}
 
 fun! togglequickfix#Has(typ) "{{{


### PR DESCRIPTION
In neovim the function tends to complain about nonexisting key
in a dictionary returned from getqflist() and getloclist().

This change fixes it by checking if the returned dictionary
is empty instead of trying to get value from it without checking.